### PR TITLE
Fixes and Features

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -9,6 +9,8 @@ setopt nobeep                                                   # No beep
 setopt appendhistory                                            # Immediately append history instead of overwriting
 setopt histignorealldups                                        # If a new command is a duplicate, remove the older one
 setopt autocd                                                   # if only directory path is entered, cd there.
+setopt inc_append_history                                       # save commands are added to the history immediately, otherwise only when shell exits.
+setopt extended_history                                         # records timestamps of each command in HISTFILE
 
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'       # Case insensitive tab completion
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"         # Colored completion (different colors for dirs/files/etc)
@@ -18,8 +20,9 @@ zstyle ':completion:*' accept-exact '*(N)'
 zstyle ':completion:*' use-cache on
 zstyle ':completion:*' cache-path ~/.zsh/cache
 HISTFILE=~/.zhistory
-HISTSIZE=1000
-SAVEHIST=500
+HISTSIZE=10000
+SAVEHIST=10000
+export HISTTIMEFORMAT="[%F %T] "
 #export EDITOR=/usr/bin/nano
 #export VISUAL=/usr/bin/nano
 WORDCHARS=${WORDCHARS//\/[&.;]}                                 # Don't consider certain characters part of the word


### PR DESCRIPTION
fix limit of history output
HISTSIZE=10000
SAVEHIST=10000

add new options:
setopt inc_append_history # save commands are added to the history immediately, otherwise only when shell exits.
setopt extended_history # records timestamps of each command in HISTFILE

Add timestamps
export HISTTIMEFORMAT="[%F %T] "